### PR TITLE
Fix a bug in octree.to_points()

### DIFF
--- a/ocnn/octree/octree.py
+++ b/ocnn/octree/octree.py
@@ -494,7 +494,6 @@ class Octree:
     if xyz is None:
       x, y, z, batch_id = self.xyzb(depth, nempty=True)
       xyz = torch.stack([x, y, z], dim=1) + 0.5
-      rescale = True
 
     # normalize xyz to [-1, 1] since the average points are in range [0, 2^d]
     if rescale:

--- a/ocnn/octree/octree.py
+++ b/ocnn/octree/octree.py
@@ -494,11 +494,12 @@ class Octree:
     if xyz is None:
       x, y, z, batch_id = self.xyzb(depth, nempty=True)
       xyz = torch.stack([x, y, z], dim=1) + 0.5
+      rescale = True
 
     # normalize xyz to [-1, 1] since the average points are in range [0, 2^d]
     if rescale:
       scale = 2 ** (1 - depth)
-      xyz = self.points[depth] * scale - 1.0
+      xyz = xyz * scale - 1.0
 
     # construct Points
     out = Points(xyz, self.normals[depth], self.features[depth],


### PR DESCRIPTION
Hi!

Thank you so much for the great work! I fixed a bug in octree.to_points() which does not rescale the coordinates of xyz correctly when self.points[self.depth] is None. Could you please check the code and merge it if this change looks good to you?

Thanks!