### PR TITLE
Fix batched octree split/grow bookkeeping

### DIFF
--- a/ocnn/octree/octree.py
+++ b/ocnn/octree/octree.py
@@ -302,6 +302,9 @@ class Octree:
     batch_size = self.batch_size
     self.nnum[depth] = num * batch_size
     self.nnum_nempty[depth] = num * batch_size
+    batch_nnum = torch.full((batch_size,), num, dtype=torch.long)
+    self.batch_nnum[depth] = batch_nnum
+    self.batch_nnum_nempty[depth] = batch_nnum
 
     # update key
     key = torch.arange(num, dtype=torch.long, device=self.device)
@@ -334,15 +337,22 @@ class Octree:
     sum = cumsum(split, dim=0, exclusive=True)
     children, nnum_nempty = torch.split(sum, [split.shape[0], 1])
     children[empty] = -1
+    batch_id = self.batch_id(depth)
+    batch_nnum = torch.bincount(batch_id.cpu(), minlength=self.batch_size)
+    batch_nnum_nempty = torch.bincount(
+        batch_id[~empty].cpu(), minlength=self.batch_size)
 
     # boundary case, make sure that at least one octree node is splitted
     if nnum_nempty == 0:
       nnum_nempty = 1
       children[0] = 0
+      batch_nnum_nempty[batch_id[0].item()] = 1
 
     # update octree
     self.children[depth] = children.int()
     self.nnum_nempty[depth] = nnum_nempty
+    self.batch_nnum[depth] = batch_nnum
+    self.batch_nnum_nempty[depth] = batch_nnum_nempty
 
     # reset nempty_masks, nempty_indices, and nempty_neighs as they depend on
     # children[depth] and are invalid now
@@ -376,7 +386,7 @@ class Octree:
       zero = torch.zeros(1, dtype=torch.long)
       self.nnum = torch.cat([self.nnum, zero])
       self.nnum_nempty = torch.cat([self.nnum_nempty, zero])
-      zero = zero.view(1, 1)
+      zero = torch.zeros(1, self.batch_size, dtype=torch.long)
       self.batch_nnum = torch.cat([self.batch_nnum, zero], dim=0)
       self.batch_nnum_nempty = torch.cat([self.batch_nnum_nempty, zero], dim=0)
 
@@ -384,6 +394,9 @@ class Octree:
     nnum = self.nnum_nempty[depth-1] * 8
     self.nnum[depth] = nnum
     self.nnum_nempty[depth] = nnum  # initialize self.nnum_nempty
+    batch_nnum = self.batch_nnum_nempty[depth-1] * 8
+    self.batch_nnum[depth] = batch_nnum
+    self.batch_nnum_nempty[depth] = batch_nnum
 
     # update keys
     key = self.key(depth-1, nempty=True)

--- a/test/test_octree.py
+++ b/test/test_octree.py
@@ -175,8 +175,32 @@ class TesOctree(unittest.TestCase):
     octree.normals[depth] = octree_gt.normals[depth]
 
     self.check_octree(octree, data)
+    self.assertTrue(torch.equal(octree.batch_nnum, octree_gt.batch_nnum))
+    self.assertTrue(torch.equal(
+        octree.batch_nnum_nempty, octree_gt.batch_nnum_nempty))
     self.assertTrue(np.array_equal(
         torch.cat(octree.neighs[1:], dim=0).numpy(), data['neigh']))
+
+  def test_octree_grow_extend_batched_depth(self):
+    depth = 4
+    batch_size = 8
+    octree = ocnn.octree.init_octree(
+        depth=depth, full_depth=depth, batch_size=batch_size)
+
+    split = torch.ones(octree.nnum[depth], dtype=torch.long)
+    octree.octree_split(split, depth)
+    octree.octree_grow(depth + 1)
+
+    expected = torch.full((batch_size,), 1 << (3 * (depth + 1)),
+                          dtype=torch.long)
+    batch_nnum = torch.bincount(
+        octree.batch_id(depth + 1), minlength=batch_size)
+
+    self.assertTrue(torch.equal(octree.batch_nnum[depth + 1], expected))
+    self.assertTrue(torch.equal(
+        octree.batch_nnum_nempty[depth + 1], expected))
+    self.assertTrue(torch.equal(batch_nnum, expected))
+    self.assertEqual(octree.nnum[depth + 1].item(), expected.sum().item())
 
   def test_octree_neigh(self):
 


### PR DESCRIPTION
## Summary

This PR fixes batched `Octree` updates when `batch_size > 1`, especially the
`octree_split()` + `octree_grow()` path.

Changes:
- fix `Octree.octree_grow()` when growing to a new depth for batched octrees
- initialize and maintain `batch_nnum` / `batch_nnum_nempty` in
  `octree_grow_full()`, `octree_split()`, and `octree_grow()`
- add regression tests for batched grow behavior, including the case:
  `init_octree(..., batch_size > 1) -> octree_split() -> octree_grow(new_depth)`

Created by Codex.

## Minimal Repro

The bug can be reproduced with the following minimal example:

```python
import torch, ocnn

octree = ocnn.octree.init_octree(
    depth=4, full_depth=4, batch_size=8, device='cpu')
labels = torch.ones(octree.nnum[4], dtype=torch.long)
octree.octree_split(labels, 4)
octree.octree_grow(5)  # crashes before this fix
```

Before this fix, the code above failed with:

```text
RuntimeError: Sizes of tensors must match except in dimension 0.
Expected size 8 but got size 1 for tensor number 1 in the list.
```

Expected behavior:
- `octree_grow(5)` should succeed
- per-batch node counts should remain consistent after `split()` / `grow()`

## Root Cause

The direct crash came from `Octree.octree_grow()` when `depth > self.depth`:
it appended a `1 x 1` tensor to `batch_nnum` and `batch_nnum_nempty`, but those
tensors have shape `[num_depths, batch_size]`. This fails as soon as
`batch_size > 1`.

There was also a deeper bookkeeping issue:
- `octree_grow_full()` did not initialize per-batch node counters
- `octree_split()` updated global counts but not per-batch counts
- `octree_grow()` expanded child nodes from global counts, but left per-batch
  counters stale

As a result, batched octrees could have valid global node counts while
`batch_nnum` and `batch_nnum_nempty` stayed zero or inconsistent.

## Why `autoencoder.py` Looked Fine

`ocnn/models/autoencoder.py` uses the same `octree_split()` / `octree_grow()`
APIs, but the problematic branch is easier to miss in practice:

- training and test paths usually run with `update_octree=False`
- decoding initializes the output octree at the final target depth, so
  `octree_grow()` usually fills an already allocated level instead of extending
  `self.depth`

That is why the bug is easier to expose with the minimal repro above than from
the standard autoencoder training path.

## Changes in This PR

- set `batch_nnum` and `batch_nnum_nempty` in `octree_grow_full()`
- recompute `batch_nnum` and `batch_nnum_nempty` in `octree_split()`
- fix the appended tensor shape in `octree_grow()` when extending to a new
  depth
- propagate per-batch counts in `octree_grow()` from the previous depth
- extend `test.test_octree` to verify batched bookkeeping and the
  `depth -> depth + 1` grow case

## Affected Configs / Datasets

None.

## Testing

Ran:

```bash
python -m unittest test.test_octree
```
